### PR TITLE
Implement LLM provider trait and adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +547,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb84100978c1c7b37f09ed3ce3e5f843af02c2a2c431bae5b19230dad2c1b490"
+dependencies = [
+ "async-trait",
+ "deadpool-runtime",
+ "num_cpus",
+ "tokio 1.45.1",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,6 +986,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,6 +1004,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite 0.2.16",
  "smallvec 1.15.0",
@@ -1312,11 +1347,13 @@ name = "llm-client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "reqwest",
  "rstest",
  "serde",
  "serde_json",
  "tokio 1.45.1",
+ "wiremock",
 ]
 
 [[package]]
@@ -3435,6 +3472,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "101681b74cd87b5899e87bcf5a64e83334dd313fcd3053ea72e6dba18928e301"
+dependencies = [
+ "assert-json-diff",
+ "async-trait",
+ "base64 0.22.1",
+ "deadpool",
+ "futures 0.3.31",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio 1.45.1",
+ "url",
 ]
 
 [[package]]

--- a/crates/llm-client/Cargo.toml
+++ b/crates/llm-client/Cargo.toml
@@ -10,6 +10,8 @@ reqwest = { version = "0.12", features = ["json", "native-tls"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+async-trait = "0.1"
 
 [dev-dependencies]
 rstest = "0.18"
+wiremock = "0.6"

--- a/crates/llm-client/src/lib.rs
+++ b/crates/llm-client/src/lib.rs
@@ -1,8 +1,21 @@
 #![deny(clippy::all)]
 
 use anyhow::Result;
+use async_trait::async_trait;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
+
+/// Prompt sent to an LLM provider.
+#[derive(Debug, Clone)]
+pub struct Prompt {
+    pub text: String,
+}
+
+/// Response returned by an LLM provider.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Resp {
+    pub text: String,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Provider {
@@ -20,35 +33,132 @@ pub struct LlmConfig {
     pub model: String,
 }
 
-/// Send a prompt to the configured LLM provider.
-pub async fn send_completion(cfg: &LlmConfig, prompt: &str) -> Result<String> {
-    let client = Client::new();
-    let body = serde_json::json!({"model": cfg.model, "prompt": prompt});
-    let res = client
-        .post(&cfg.base_url)
-        .bearer_auth(cfg.api_key.clone().unwrap_or_default())
-        .json(&body)
-        .send()
-        .await?;
-    let json: serde_json::Value = res.json().await?;
-    Ok(json["choices"][0]["text"].as_str().unwrap_or_default().to_string())
+#[async_trait]
+pub trait LlmProvider: Send + Sync {
+    async fn complete(&self, req: Prompt) -> Result<Resp>;
+}
+
+#[derive(Debug, Clone)]
+struct HttpProvider {
+    client: Client,
+    base_url: String,
+    api_key: Option<String>,
+    model: String,
+}
+
+impl HttpProvider {
+    fn new(base_url: String, api_key: Option<String>, model: String) -> Self {
+        Self { client: Client::new(), base_url, api_key, model }
+    }
+}
+
+#[async_trait]
+impl LlmProvider for HttpProvider {
+    async fn complete(&self, req: Prompt) -> Result<Resp> {
+        let body = serde_json::json!({"model": self.model, "prompt": req.text});
+        let mut req = self.client.post(&self.base_url).json(&body);
+        if let Some(key) = &self.api_key {
+            req = req.bearer_auth(key);
+        }
+        let res = req.send().await?;
+        let json: serde_json::Value = res.json().await?;
+        Ok(Resp { text: json["choices"][0]["text"].as_str().unwrap_or_default().to_string() })
+    }
+}
+
+macro_rules! adapter {
+    ($name:ident) => {
+        #[derive(Debug, Clone)]
+        pub struct $name(HttpProvider);
+
+        impl $name {
+            pub fn new(base_url: String, api_key: Option<String>, model: String) -> Self {
+                Self(HttpProvider::new(base_url, api_key, model))
+            }
+        }
+
+        #[async_trait]
+        impl LlmProvider for $name {
+            async fn complete(&self, req: Prompt) -> Result<Resp> {
+                self.0.complete(req).await
+            }
+        }
+    };
+}
+
+adapter!(Ollama);
+adapter!(OpenRouter);
+adapter!(AIFoundry);
+adapter!(Custom);
+
+pub fn provider_from_config(cfg: &LlmConfig) -> Box<dyn LlmProvider> {
+    match cfg.provider {
+        Provider::Ollama => Box::new(Ollama::new(cfg.base_url.clone(), cfg.api_key.clone(), cfg.model.clone())),
+        Provider::OpenRouter => Box::new(OpenRouter::new(cfg.base_url.clone(), cfg.api_key.clone(), cfg.model.clone())),
+        Provider::AIFoundry => Box::new(AIFoundry::new(cfg.base_url.clone(), cfg.api_key.clone(), cfg.model.clone())),
+        Provider::Custom => Box::new(Custom::new(cfg.base_url.clone(), cfg.api_key.clone(), cfg.model.clone())),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use rstest::rstest;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+    use wiremock::matchers::{method, path};
+
+    async fn setup_mock() -> MockServer {
+        MockServer::start().await
+    }
+
+    async fn mount_success(mock: &MockServer) {
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                "{\"choices\":[{\"text\":\"pong\"}]}",
+                "application/json",
+            ))
+            .mount(mock)
+            .await;
+    }
 
     #[rstest]
     #[tokio::test]
-    async fn test_send_completion() {
-        let cfg = LlmConfig {
-            provider: Provider::Custom,
-            base_url: "http://localhost".into(),
-            api_key: None,
-            model: "test".into(),
-        };
-        // This will fail because there is no server, but we expect an error
-        assert!(send_completion(&cfg, "hi").await.is_err());
+    async fn ollama_complete() {
+        let mock = setup_mock().await;
+        mount_success(&mock).await;
+        let provider = Ollama::new(mock.uri(), None, "test".into());
+        let resp = provider.complete(Prompt { text: "ping".into() }).await.unwrap();
+        assert_eq!(resp.text, "pong");
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn openrouter_complete() {
+        let mock = setup_mock().await;
+        mount_success(&mock).await;
+        let provider = OpenRouter::new(mock.uri(), None, "test".into());
+        let resp = provider.complete(Prompt { text: "ping".into() }).await.unwrap();
+        assert_eq!(resp.text, "pong");
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn aifoundry_complete() {
+        let mock = setup_mock().await;
+        mount_success(&mock).await;
+        let provider = AIFoundry::new(mock.uri(), None, "test".into());
+        let resp = provider.complete(Prompt { text: "ping".into() }).await.unwrap();
+        assert_eq!(resp.text, "pong");
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn custom_complete() {
+        let mock = setup_mock().await;
+        mount_success(&mock).await;
+        let provider = Custom::new(mock.uri(), None, "test".into());
+        let resp = provider.complete(Prompt { text: "ping".into() }).await.unwrap();
+        assert_eq!(resp.text, "pong");
     }
 }

--- a/crates/openwarp-cli/src/main.rs
+++ b/crates/openwarp-cli/src/main.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 use clap::Parser;
-use llm_client::{send_completion, LlmConfig, Provider};
+use llm_client::{provider_from_config, LlmConfig, Provider, Prompt};
 use terminal_core::{run, Block};
 use tokio_stream::StreamExt;
 use std::process::Command;
@@ -32,7 +32,8 @@ async fn main() -> Result<()> {
         api_key: None,
         model: args.model.clone(),
     };
-    let _ = send_completion(&cfg, "hello").await.ok();
+    let provider = provider_from_config(&cfg);
+    let _ = provider.complete(Prompt { text: "hello".into() }).await.ok();
 
     let mut cmd = Command::new("sh");
     cmd.arg("-c").arg("echo openwarp");


### PR DESCRIPTION
## Summary
- define `LlmProvider` trait and request/response structs
- add HTTP-based adapters for Ollama, OpenRouter, AI-Foundry and Custom
- expose `provider_from_config` helper
- update CLI to use the new provider trait
- unit test adapters with `wiremock`

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6841e3e21ea4832d90f1b60de0223ef3