### PR TITLE
Add release documentation and SBOM workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,36 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Build one-click EXE
         run: pwsh scripts/build_windows.ps1
+      - name: Sign EXE
+        if: env.WINDOWS_CERT != ''
+        run: signtool sign /fd SHA256 /a /f $env:WINDOWS_CERT dist\clappy.exe
       - uses: actions/upload-artifact@v4
         with:
           path: dist/clappy.exe
+  macos-package:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-rust@v3
+        with:
+          rust-version: 'stable'
+      - name: Build dmg
+        run: bash scripts/build_macos.sh
+      - name: Sign dmg
+        if: env.APPLE_CERT != ''
+        run: codesign --timestamp --sign "$APPLE_CERT" target/release/bundle/dmg/*.dmg
+      - uses: actions/upload-artifact@v4
+        with:
+          path: target/release/bundle/dmg/*.dmg
+
+  sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-rust@v3
+        with:
+          rust-version: 'stable'
+      - run: bash scripts/generate_sbom.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          path: sbom.xml*

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,18 @@
+# Release Process
+
+## 23. Full QA & Release Candidate
+- Run unit tests and `cargo clippy`.
+- Execute Cypress UI tests: `pnpm --dir app run test:e2e`.
+- Check for memory leaks with `valgrind` on Linux and Instruments on macOS.
+- Perform accessibility audit via `pnpm --dir app run a11y`.
+- Sign Windows and macOS bundles using your platform certificates.
+- Generate a CycloneDX SBOM and detach signature with `scripts/generate_sbom.sh`.
+
+## 24. v1.0.0 Production Release
+- Tag the release:
+  ```bash
+  git tag v1.0.0 && git push origin v1.0.0
+  ```
+- Publish artifacts `CLAppySetup.exe`, `.dmg`, and `.AppImage`.
+- Provide SHA256 checksums for each artifact.
+- Post the launch announcement and create `docs/roadmap.md` for v1.1.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,6 @@
+# Roadmap
+
+## v1.1 Goals
+- Voice input for hands-free commands.
+- Collaborative sessions with shared cursors.
+- SSH relay support for remote terminals.

--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+cargo tauri build --release
+DMG=$(ls target/release/bundle/dmg/*.dmg)
+if [ -n "$APPLE_CERT" ]; then
+  codesign --timestamp --sign "$APPLE_CERT" "$DMG"
+fi

--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -3,3 +3,6 @@ $msi = Get-ChildItem target\release\bundle\msi\*.msi
 Copy-Item -Recurse share\examples target\release\bundle\msi\
 & makensis /DMSI=$msi installer.nsi
 & pkgforge pack installer\nsis\clappy_installer.exe -o dist\clappy.exe --silent
+if ($env:WINDOWS_CERT) {
+    signtool sign /fd SHA256 /a /f $env:WINDOWS_CERT dist\clappy.exe
+}

--- a/scripts/generate_sbom.sh
+++ b/scripts/generate_sbom.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+cargo install --locked cargo-cyclonedx --root ./target/cyclonedx >/dev/null 2>&1 || true
+PATH=./target/cyclonedx/bin:$PATH cargo cyclonedx --all --format xml --output sbom.xml
+if command -v gpg >/dev/null 2>&1; then
+  gpg --batch --yes --armor --detach-sign sbom.xml
+fi


### PR DESCRIPTION
## Summary
- document QA and release steps
- outline roadmap for v1.1
- add macOS build script
- enable Windows signing in packaging script and CI
- add SBOM generation job in CI

## Testing
- `cargo test --workspace` *(failed: hung)*
- `pnpm --dir app run lint` *(failed: missing eslint config)*
- `bash scripts/generate_sbom.sh` *(failed: no output)*


------
https://chatgpt.com/codex/tasks/task_e_68422e488a24832db2ca0b525c66bfea