### PR TITLE
Prep for 1.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clappy-cli"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1517,7 +1517,7 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "llm-client"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1889,7 +1889,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plugin-sdk"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "llm-client",
@@ -2513,7 +2513,7 @@ dependencies = [
 
 [[package]]
 name = "terminal-core"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "futures 0.1.31",

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Run `cargo check` in the repo root to verify all Rust crates.
 Install with `cargo install --path crates/clappy-cli` and run `clappy --provider ollama --model llama3`.
 The CLI features a dynamic command router. Enter a shell name (`bash`, `pwsh`, `cmd`) to spawn that shell, `/model <name>` to hot-swap the model, or any natural language which will be converted to a shell command using the selected provider. Telemetry is disabled unless `--insecure-telemetry` is passed.
 
+## Production Release
+
+CLAppy **1.0.0** is now available. Install the CLI from crates.io or grab the signed desktop installers from the GitHub Releases page.
+
 ## Windows Build
 Run `pwsh scripts/build_setup.ps1` to create a single `clappy.exe` in the `dist` folder. The script now configures Visual Studio build tools, Node and Rust automatically before bundling the Tauri MSI with NSIS and `pkgforge` for a one-click installer.
 

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clappy-app",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "scripts": {
     "tauri": "tauri dev",
     "lint": "eslint . --ext .ts,.tsx --max-warnings=0",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clappy-app"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/clappy-cli/Cargo.toml
+++ b/crates/clappy-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clappy-cli"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2024"
 authors = ["CLAppy Contributors"]
 

--- a/crates/clappy-e2e/Cargo.toml
+++ b/crates/clappy-e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clappy-e2e"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/llm-client/Cargo.toml
+++ b/crates/llm-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-client"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2024"
 authors = ["CLAppy Contributors"]
 

--- a/crates/plugin-sdk/Cargo.toml
+++ b/crates/plugin-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plugin-sdk"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2024"
 authors = ["CLAppy Contributors"]
 

--- a/crates/terminal-core/Cargo.toml
+++ b/crates/terminal-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminal-core"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2024"
 authors = ["CLAppy Contributors"]
 

--- a/docs/plugin_api.yaml
+++ b/docs/plugin_api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: CLAppy Plugin API
-  version: 0.1.0
+  version: 1.0.0
 paths:
   /run:
     post:

--- a/docs/release.md
+++ b/docs/release.md
@@ -2,6 +2,7 @@
 
 ## 23. Full QA & Release Candidate
 - Run unit tests and `cargo clippy`.
+- Bump crate versions to `1.0.0` across the workspace.
 - Execute Cypress UI tests: `pnpm --dir app run test:e2e`.
 - Check for memory leaks with `valgrind` on Linux and Instruments on macOS.
 - Perform accessibility audit via `pnpm --dir app run a11y`.


### PR DESCRIPTION
## Summary
- bump workspace crates and app to version 1.0.0
- update release docs with version bump step
- document production release in README
- update plugin API version

## Testing
- `cargo check -p clappy-cli` *(failed: process killed due to time or resource limits)*

------
https://chatgpt.com/codex/tasks/task_e_68439281d76c832db8e159a004ec62e8